### PR TITLE
Fix loginInit to avoid infinite loop in client

### DIFF
--- a/client/src/js/login.js
+++ b/client/src/js/login.js
@@ -189,7 +189,7 @@ function checkSetup() {
 function loginInit() {
 	let id = getCookie("session");
 	let uid = getCookie("userid");
-	if (id == "" || uid == "") {
+	if (id == null || uid == null) {
 		session = {};
 		reg();
 	} else {

--- a/client/src/js/login.js
+++ b/client/src/js/login.js
@@ -189,7 +189,7 @@ function checkSetup() {
 function loginInit() {
 	let id = getCookie("session");
 	let uid = getCookie("userid");
-	if (id == null || uid == null) {
+	if (!id || !uid) {
 		session = {};
 		reg();
 	} else {


### PR DESCRIPTION
Using `null` instead of `""` fixes the issue where the user didn't get the registration/login popup due to the client expecting `session` and `userid` values in cookies to be `""`. If `session` and `userid` weren't created in cookies, it would attempt to connect to a nonexistent session.